### PR TITLE
Fix calculation of item amount with non-rounded dollar values.

### DIFF
--- a/lib/paypal/payment/request.rb
+++ b/lib/paypal/payment/request.rb
@@ -28,7 +28,7 @@ module Paypal
           v.blank?
         end
         if self.items.present?
-          params[:"PAYMENTREQUEST_#{index}_ITEMAMT"] = Util.formatted_amount(items.sum(&:amount).to_i)
+          params[:"PAYMENTREQUEST_#{index}_ITEMAMT"] = Util.formatted_amount(items.sum(&:amount))
           self.items.each_with_index do |item, item_index|
             params.merge! item.to_params(index, item_index)
           end

--- a/spec/paypal/payment/request_spec.rb
+++ b/spec/paypal/payment/request_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper.rb'
 describe Paypal::Payment::Request do
   let :instant_request do
     Paypal::Payment::Request.new(
-      :amount => 10,
+      :amount => 10.25,
       :currency_code => :JPY,
       :description => 'Instant Payment Request',
       :notify_url => 'http://merchant.example.com/notify',
       :items => [{
         :name => 'Item1',
         :description => 'Awesome Item!',
-        :amount => 10
+        :amount => 10.25
       }]
     )
   end
@@ -25,7 +25,7 @@ describe Paypal::Payment::Request do
 
   describe '.new' do
     it 'should handle Instant Payment parameters' do
-      instant_request.amount.should == 10
+      instant_request.amount.should == 10.25
       instant_request.currency_code.should == :JPY
       instant_request.description.should == 'Instant Payment Request'
       instant_request.notify_url.should == 'http://merchant.example.com/notify'
@@ -41,14 +41,14 @@ describe Paypal::Payment::Request do
   describe '#to_params' do
     it 'should handle Instant Payment parameters' do
       instant_request.to_params.should == {
-        :PAYMENTREQUEST_0_AMT => "10.00",
+        :PAYMENTREQUEST_0_AMT => "10.25",
         :PAYMENTREQUEST_0_CURRENCYCODE => :JPY,
         :PAYMENTREQUEST_0_DESC => "Instant Payment Request", 
         :PAYMENTREQUEST_0_NOTIFYURL => "http://merchant.example.com/notify",
-        :PAYMENTREQUEST_0_ITEMAMT => "10.00",
+        :PAYMENTREQUEST_0_ITEMAMT => "10.25",
         :L_PAYMENTREQUEST_0_NAME0 => "Item1",
         :L_PAYMENTREQUEST_0_DESC0 => "Awesome Item!",
-        :L_PAYMENTREQUEST_0_AMT0 => "10.00",
+        :L_PAYMENTREQUEST_0_AMT0 => "10.25",
         :L_PAYMENTREQUEST_0_QTY0 => 1
       }
     end


### PR DESCRIPTION
There is a bug in the summation of item amounts in the current code.  It currently assumes that all amount values will be rounded to whole dollars, which is not required by the PayPal API.

Currently, if you create an item with a non-rounded amount, the following request is generated (and PayPal's response returns the following error):

```
CANCELURL=http%3A%2F%2Fkozeyrosenbaum.biz&L_PAYMENTREQUEST_0_AMT0=23.56&L_PAYMENTREQUEST_0_NAME0=Sincere+Murray&L_PAYMENTREQUEST_0_QTY0=1&PAYMENTREQUEST_0_AMT=23.56&PAYMENTREQUEST_0_CURRENCYCODE=USD&PAYMENTREQUEST_0_ITEMAMT=23.00&RETURNURL=http%3A%2F%2Fkozeyrosenbaum.biz
```

(Notice that the `PAYMENTREQUEST_0_ITEMAMT` is `23.00`, not `23.56`)
    TIMESTAMP=2011%2d03%2d29T13%3a16%3a31Z&CORRELATIONID=e92606683b81&ACK=Failure&VERSION=69%2e0&BUILD=1799695&L_ERRORCODE0=10413&L_SHORTMESSAGE0=Transaction%20refused%20because%20of%20an%20invalid%20argument%2e%20See%20additional%20error%20messages%20for%20details%2e&L_LONGMESSAGE0=The%20totals%20of%20the%20cart%20item%20amounts%20do%20not%20match%20order%20amounts%2e&L_SEVERITYCODE0=Error

This patch contains updated tests and the fix.
