### PR TITLE
Meaningful details in APIError#message

### DIFF
--- a/lib/paypal/exception/api_error.rb
+++ b/lib/paypal/exception/api_error.rb
@@ -8,7 +8,15 @@ module Paypal
         else
           response
         end
-        super 'PayPal API Error'
+      end
+
+      def message
+        if response.respond_to?(:short_messages) && response.short_messages.any?
+          "PayPal API Error: " <<
+            response.short_messages.map{ |m| "'#{m}'" }.join(", ")
+        else
+          "PayPal API Error"
+        end
       end
 
       class Response
@@ -74,6 +82,10 @@ module Paypal
           attrs.each do |key, value|
             Paypal.log "Ignored Parameter (#{self.class}): #{key}=#{value}", :warn
           end
+        end
+
+        def short_messages
+          details.map(&:short_message).compact
         end
       end
     end

--- a/spec/paypal/exception/api_error_spec.rb
+++ b/spec/paypal/exception/api_error_spec.rb
@@ -9,13 +9,24 @@ describe Paypal::Exception::APIError do
         :VERSION=>"66.0",
         :TIMESTAMP=>"2011-03-03T06:33:51Z",
         :CORRELATIONID=>"758ebdc546b9c",
+        :BUILD=>"1741654",
+        :ACK=>"Failure",
         :L_SEVERITYCODE0=>"Error",
         :L_ERRORCODE0=>"10411",
         :L_LONGMESSAGE0=>"This Express Checkout session has expired.  Token value is no longer valid.",
-        :BUILD=>"1741654",
-        :ACK=>"Failure",
-        :L_SHORTMESSAGE0=>"This Express Checkout session has expired."
+        :L_SHORTMESSAGE0=>"This Express Checkout session has expired.",
+        :L_SEVERITYCODE1=>"Error",
+        :L_ERRORCODE1=>"2468",
+        :L_LONGMESSAGE1=>"Sample of a long message for the second item.",
+        :L_SHORTMESSAGE1=>"Second short message.",
       }
+    end
+
+    describe "#message" do
+      it "aggregates short messages" do
+        error.message.should ==
+          "PayPal API Error: 'This Express Checkout session has expired.', 'Second short message.'"
+      end
     end
 
     describe '#subject' do
@@ -55,11 +66,13 @@ describe Paypal::Exception::APIError do
       subject { error.response }
       its(:raw) { should == params }
     end
+    its(:message) { should == "PayPal API Error" }
   end
 
   context 'otherwise' do
     subject { error }
     let(:params) { 'Failure' }
     its(:response) { should == params }
+    its(:message) { should == "PayPal API Error" }
   end
 end


### PR DESCRIPTION
It's very frustrating getting exceptions like "PayPal API Error" without any hint what went wrong. This is especially true when the errors originate with a third party and may not be reproducible.

Of course it's possible to guard every call to paypal-express with rescue code picking apart the exception to log/report/alert the actual reason.

However it would be nice if paypal-express gave more helpful errors in the first place.

This patch to APIError builds a message based on the short_messages of the individual line items, as long as they are present. Otherwise it falls back to the default "PayPal API Error" message.

What do you think?

PS: Thanks for writing paypal-express! :)
