### PR TITLE
Fixing Paypal::Util#formatted_amount to round better the value.

### DIFF
--- a/lib/paypal/util.rb
+++ b/lib/paypal/util.rb
@@ -3,7 +3,7 @@ module Paypal
 
     def self.formatted_amount(x)
       # Thanks @nahi ;)
-      sprintf "%0.2f", BigDecimal.new(x.to_s).truncate(2)
+      sprintf "%0.2f", BigDecimal.new(x.to_s).round(2)
     end
 
     def self.to_numeric(x)


### PR DESCRIPTION
Sometimes the value would be, in BigDecimal format, a continuous decimal, like 451.3499999997 (for a real value of 451.35), and truncating it would give us 451.34 instead of 451.35.

Using #round instead of #truncate solves this.

http://cdn.memegenerator.net/instances/400x/16838681.jpg
