### PR TITLE
Add support for SUBJECT parameter.

### DIFF
--- a/lib/paypal/nvp/request.rb
+++ b/lib/paypal/nvp/request.rb
@@ -2,6 +2,7 @@ module Paypal
   module NVP
     class Request < Base
       attr_required :username, :password, :signature
+      attr_optional :subject
       attr_accessor :version
 
       ENDPOINT = {
@@ -27,6 +28,7 @@ module Paypal
           :USER => self.username,
           :PWD => self.password,
           :SIGNATURE => self.signature,
+          :SUBJECT => self.subject,
           :VERSION => self.version
         }
       end

--- a/spec/paypal/nvp/request_spec.rb
+++ b/spec/paypal/nvp/request_spec.rb
@@ -47,6 +47,35 @@ describe Paypal::NVP::Request do
         end
       end
     end
+
+    context 'when optional parameters are given' do
+      let(:optional_attributes) do
+        { :subject => 'user@example.com' }
+      end
+
+      it 'should setup subject' do
+        client = Paypal::NVP::Request.new attributes.merge(optional_attributes)
+        client.subject.should == 'user@example.com'
+      end
+    end
+  end
+
+  describe '#common_params' do
+    {
+      :username => :USER,
+      :password => :PWD,
+      :signature => :SIGNATURE,
+      :subject => :SUBJECT,
+      :version => :VERSION
+    }.each do |option_key, param_key|
+      it "should include :#{param_key}" do
+        instance.common_params.should include(param_key)
+      end
+
+      it "should set :#{param_key} as #{option_key}" do
+        instance.common_params[param_key].should == instance.send(option_key)
+      end
+    end
   end
 
   describe '#request' do


### PR DESCRIPTION
Hi!

I'm working on a project where I have to make requests on behalf of other merchants. API credentials can have optional SUBJECT parameter to specify the email address of the third-party merchant on whose behalf you are calling the API operation.

Thank you for the great library!
Alex
