### PR TITLE
Added item amount so that the sum of the amounts equals AMT

### DIFF
--- a/lib/paypal/payment/request.rb
+++ b/lib/paypal/payment/request.rb
@@ -11,7 +11,8 @@ module Paypal
           Common::Amount.new(
             :total => attributes[:amount],
             :tax => attributes[:tax_amount],
-            :shipping => attributes[:shipping_amount]
+            :shipping => attributes[:shipping_amount],
+            :item => attributes[:item_amount]
           )
         end
         @items = []
@@ -27,6 +28,7 @@ module Paypal
           :"PAYMENTREQUEST_#{index}_AMT" => Util.formatted_amount(self.amount.total),
           :"PAYMENTREQUEST_#{index}_TAXAMT" => Util.formatted_amount(self.amount.tax),
           :"PAYMENTREQUEST_#{index}_SHIPPINGAMT" => Util.formatted_amount(self.amount.shipping),
+          :"PAYMENTREQUEST_#{index}_ITEMAMT" => Util.formatted_amount(self.amount.item),
           :"PAYMENTREQUEST_#{index}_CURRENCYCODE" => self.currency_code,
           :"PAYMENTREQUEST_#{index}_DESC" => self.description,
           # NOTE:

--- a/spec/paypal/express/request_spec.rb
+++ b/spec/paypal/express/request_spec.rb
@@ -121,6 +121,7 @@ describe Paypal::Express::Request do
         :PAYMENTREQUEST_0_AMT => '1000.00',
         :PAYMENTREQUEST_0_TAXAMT => "0.00",
         :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00",
+        :PAYMENTREQUEST_0_ITEMAMT => "0.00",
         :REQCONFIRMSHIPPING => 0,
         :NOSHIPPING => 1
       }
@@ -155,7 +156,8 @@ describe Paypal::Express::Request do
           :CANCELURL => cancel_url,
           :PAYMENTREQUEST_0_AMT => '1000.00',
           :PAYMENTREQUEST_0_TAXAMT => "0.00",
-          :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00"
+          :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00",
+          :PAYMENTREQUEST_0_ITEMAMT => "0.00"
         }
       end
     end
@@ -173,7 +175,8 @@ describe Paypal::Express::Request do
           :CANCELURL => cancel_url,
           :PAYMENTREQUEST_0_AMT => '0.00',
           :PAYMENTREQUEST_0_TAXAMT => "0.00",
-          :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00"
+          :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00",
+          :PAYMENTREQUEST_0_ITEMAMT => "0.00"
         }
       end
     end
@@ -191,7 +194,8 @@ describe Paypal::Express::Request do
           :CANCELURL => cancel_url,
           :PAYMENTREQUEST_0_AMT => '0.00',
           :PAYMENTREQUEST_0_TAXAMT => "0.00",
-          :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00"
+          :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00",
+          :PAYMENTREQUEST_0_ITEMAMT => "0.00"
         }
       end
     end
@@ -264,7 +268,8 @@ describe Paypal::Express::Request do
         :PAYMENTREQUEST_0_DESC => 'Instant Payment Request',
         :PAYMENTREQUEST_0_AMT => '1000.00',
         :PAYMENTREQUEST_0_TAXAMT => "0.00",
-        :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00"
+        :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00",
+        :PAYMENTREQUEST_0_ITEMAMT => "0.00"
       }
     end
 

--- a/spec/paypal/payment/request_spec.rb
+++ b/spec/paypal/payment/request_spec.rb
@@ -6,6 +6,7 @@ describe Paypal::Payment::Request do
       :amount => 25.7,
       :tax_amount => 0.4,
       :shipping_amount => 1.5,
+      :item_amount => 23.8,
       :currency_code => :JPY,
       :description => 'Instant Payment Request',
       :notify_url => 'http://merchant.example.com/notify',
@@ -44,6 +45,7 @@ describe Paypal::Payment::Request do
       instant_request.amount.total.should == 25.7
       instant_request.amount.tax.should == 0.4
       instant_request.amount.shipping.should == 1.5
+      instant_request.amount.item.should == 23.8
       instant_request.currency_code.should == :JPY
       instant_request.description.should == 'Instant Payment Request'
       instant_request.notify_url.should == 'http://merchant.example.com/notify'
@@ -68,6 +70,7 @@ describe Paypal::Payment::Request do
         :PAYMENTREQUEST_0_AMT => "25.70",
         :PAYMENTREQUEST_0_TAXAMT => "0.40",
         :PAYMENTREQUEST_0_SHIPPINGAMT => "1.50",
+        :PAYMENTREQUEST_0_ITEMAMT => "23.80",
         :PAYMENTREQUEST_0_CURRENCYCODE => :JPY,
         :PAYMENTREQUEST_0_DESC => "Instant Payment Request", 
         :PAYMENTREQUEST_0_NOTIFYURL => "http://merchant.example.com/notify",
@@ -88,6 +91,7 @@ describe Paypal::Payment::Request do
         :PAYMENTREQUEST_0_AMT => "0.00",
         :PAYMENTREQUEST_0_TAXAMT => "0.00",
         :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00",
+        :PAYMENTREQUEST_0_ITEMAMT => "0.00",
         :PAYMENTREQUEST_0_CURRENCYCODE => :JPY,
         :L_BILLINGTYPE0 => :RecurringPayments,
         :L_BILLINGAGREEMENTDESCRIPTION0 => "Recurring Payment Request"
@@ -99,6 +103,7 @@ describe Paypal::Payment::Request do
         :PAYMENTREQUEST_0_AMT => "0.00",
         :PAYMENTREQUEST_0_TAXAMT => "0.00",
         :PAYMENTREQUEST_0_SHIPPINGAMT => "0.00",
+        :PAYMENTREQUEST_0_ITEMAMT => "0.00",
         :PAYMENTREQUEST_0_CURRENCYCODE => :JPY,
         :L_BILLINGTYPE0 => :MerchantInitiatedBillingSingleAgreement,
         :L_BILLINGAGREEMENTDESCRIPTION0 => "Reference Transaction Request"


### PR DESCRIPTION
When I set up shipping and tax amounts, Paypal complains that "The totals of the cart item amounts do not match order amounts". It seems `PAYMENTREQUEST_0_AMT` must be the total of all the other amounts which is not feasible with the current version. I added `item` amount support.
