### PR TITLE
Added exchange rate support to payment response info

### DIFF
--- a/lib/paypal/payment/response/info.rb
+++ b/lib/paypal/payment/response/info.rb
@@ -18,7 +18,8 @@ module Paypal
         :TRANSACTIONID => :transaction_id,
         :TRANSACTIONTYPE => :transaction_type,
         :PAYMENTREQUESTID => :request_id,
-        :SELLERPAYPALACCOUNTID => :seller_id
+        :SELLERPAYPALACCOUNTID => :seller_id,
+        :EXCHANGERATE => :exchange_rate
       }
       attr_accessor *@@attribute_mapping.values
       attr_accessor :amount

--- a/spec/paypal/payment/response/info_spec.rb
+++ b/spec/paypal/payment/response/info_spec.rb
@@ -25,7 +25,8 @@ describe Paypal::Payment::Response::Info do
       :RECEIPTID => '12345',
       :SECUREMERCHANTACCOUNTID => '123456789',
       :PAYMENTREQUESTID => '12345',
-      :SELLERPAYPALACCOUNTID => 'seller@shop.example.com'
+      :SELLERPAYPALACCOUNTID => 'seller@shop.example.com',
+      :EXCHANGERATE => '0.811965'
     }
   end
 


### PR DESCRIPTION
When dealing with multiple currencies and setting payment options to automatically do exchange rate conversion, Paypal will also include the exchange rate used in the response info, so I've added support for this.
