### PR TITLE
optional parameter locale should be called localecode

### DIFF
--- a/lib/paypal/express/request.rb
+++ b/lib/paypal/express/request.rb
@@ -18,7 +18,7 @@ module Paypal
           :landing_page  => :LANDINGPAGE,
           :email         => :EMAIL,
           :brand         => :BRANDNAME,
-          :locale        => :LOCALECODE
+          :localecode        => :LOCALECODE
         }.each do |option_key, param_key|
           params[param_key] = options[option_key] if options[option_key]
         end

--- a/spec/paypal/express/request_spec.rb
+++ b/spec/paypal/express/request_spec.rb
@@ -131,7 +131,7 @@ describe Paypal::Express::Request do
       :landing_page => :LANDINGPAGE,
       :email => :EMAIL,
       :brand => :BRANDNAME,
-      :locale => :LOCALECODE
+      :localecode => :LOCALECODE
     }.each do |option_key, param_key|
       it "should support #{option_key} option" do
         expect do


### PR DESCRIPTION
As specified here: https://www.x.com/developers/paypal/documentation-tools/api/callback-api-operation-nvp

optional parameter locale should be named localecode. 
