### PR TITLE
Fix typo and self problem

### DIFF
--- a/lib/paypal.rb
+++ b/lib/paypal.rb
@@ -6,7 +6,7 @@ require 'rest_client'
 
 module Paypal
   attr_accessor :api_version
-  self.api_version = '88.0'
+  api_version = '88.0'
 
   ENDPOINT = {
     :production => 'https://www.paypal.com/cgi-bin/webscr',


### PR DESCRIPTION
Hi, I have spotted a typo in latest version in attr_accessor and I have removed self from api_version which raised undefined method.
