### PR TITLE
Fix cattr_accessor => attr_accessor typo

### DIFF
--- a/lib/paypal.rb
+++ b/lib/paypal.rb
@@ -5,7 +5,7 @@ require 'attr_optional'
 require 'rest_client'
 
 module Paypal
-  cattr_accessor :api_version
+  attr_accessor :api_version
   self.api_version = '88.0'
 
   ENDPOINT = {


### PR DESCRIPTION
Hi, I have spotted a typo in latest version in attr_accessor. Strangely I'm getting also undefined method for api_version.
