### PR TITLE
Use mattr_accessor instead of cattr_accessor to support rails3

### DIFF
--- a/lib/paypal.rb
+++ b/lib/paypal.rb
@@ -5,7 +5,7 @@ require 'attr_optional'
 require 'rest_client'
 
 module Paypal
-  cattr_accessor :api_version
+  mattr_accessor :api_version
   self.api_version = '88.0'
 
   ENDPOINT = {


### PR DESCRIPTION
I use rails 3.2, when I try to start my app I always get undefined_method of 'cattr_accessor'
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
