### PR TITLE
Moved max_amount to Paypal::Express::Request::setup

### DIFF
--- a/lib/paypal/express/request.rb
+++ b/lib/paypal/express/request.rb
@@ -13,6 +13,9 @@ module Paypal
           params[:REQCONFIRMSHIPPING] = 0
           params[:NOSHIPPING] = 1
         end
+        if options[:max_amount]
+          params[:MAXAMT] = Util.formatted_amount options[:max_amount]
+        end
 
         params[:ALLOWNOTE] = 0 if options[:allow_note] == false
 
@@ -129,9 +132,6 @@ module Paypal
         params = {
           :TOKEN => token
         }
-        if options[:max_amount]
-          params[:MAXAMT] = Util.formatted_amount options[:max_amount]
-        end
         response = self.request :CreateBillingAgreement, params
         Response.new response
       end


### PR DESCRIPTION
Moved `max_amount` from `Paypal::Express::Request::agree!` to `Paypal::Express::Request::setup`

According to the PayPal documentation, `MAXAMT` belongs with
[SetExpressCheckout](https://developer.paypal.com/docs/classic/api/merch
ant/SetExpressCheckout_API_Operation_NVP/) and not
[CreateBillingAgreement](https://developer.paypal.com/docs/classic/api/m
erchant/CreateBillingAgreement_API_Operation_NVP/).