### PR TITLE
Allow passing bn_code to Request#checkout! via opts

### DIFF
--- a/lib/paypal/express/request.rb
+++ b/lib/paypal/express/request.rb
@@ -45,11 +45,17 @@ module Paypal
         Response.new response
       end
 
-      def checkout!(token, payer_id, payment_requests)
+      def checkout!(token, payer_id, payment_requests, opts = {})
         params = {
           :TOKEN => token,
           :PAYERID => payer_id
         }
+
+        # https://www.paypal-marketing.com/emarketing/partner/na/portal/integrate_bn_codes.html
+        if opts[:bn_code].present?
+          params[:BUTTONSOURCE] = opts[:bn_code]
+        end
+
         Array(payment_requests).each_with_index do |payment_request, index|
           params.merge! payment_request.to_params(index)
         end


### PR DESCRIPTION
We had to add bn_code support for an integration our product has with PayPal. (In our case, this is how PayPal attributes transactions we process on behalf of our clients.) I did this via an options hash passed in to the checkout! method.

While this isn't fully fleshed out, I thought it may be something useful to support. If you're interested, I can add some tests and make it a proper PR.