### PR TITLE
Fix the compatibility with rest-client 2.0

### DIFF
--- a/lib/paypal/nvp/request.rb
+++ b/lib/paypal/nvp/request.rb
@@ -21,6 +21,7 @@ module Paypal
       def initialize(attributes = {})
         @version = Paypal.api_version
         super
+        self.subject ||= ''
       end
 
       def common_params


### PR DESCRIPTION
A rule of parameter encoding changed in rest-client 2.0.

``` irb
>> RestClient::VERSION
=> "1.8.0"
>> RestClient::Payload.generate(foo: '', bar: nil)
=> "foo=&bar="
```

``` irb
>> RestClient::VERSION
=> "2.0.0"
>> RestClient::Payload.generate(foo: '', bar: nil).to_s
=> "foo=&bar"
```

Therefore an error as `PayPal API Error: 'Version error'` occurs in `Paypal::Express::Request#setup`.