### PR TITLE
Fix for "PayPal API Error: 'Version error'"

### DIFF
--- a/lib/paypal/express/request.rb
+++ b/lib/paypal/express/request.rb
@@ -7,7 +7,8 @@ module Paypal
       def setup(payment_requests, return_url, cancel_url, options = {})
         params = {
           :RETURNURL => return_url,
-          :CANCELURL => cancel_url
+          :CANCELURL => cancel_url,
+          :version   => Paypal.api_version
         }
         if options[:no_shipping]
           params[:REQCONFIRMSHIPPING] = 0
@@ -36,7 +37,10 @@ module Paypal
       end
 
       def details(token)
-        response = self.request :GetExpressCheckoutDetails, {:TOKEN => token}
+        response = self.request :GetExpressCheckoutDetails, {
+          :TOKEN   => token,
+          :version => Paypal.api_version
+        }
         Response.new response
       end
 
@@ -48,7 +52,8 @@ module Paypal
       def checkout!(token, payer_id, payment_requests)
         params = {
           :TOKEN => token,
-          :PAYERID => payer_id
+          :PAYERID => payer_id,
+          :version => Paypal.api_version
         }
         Array(payment_requests).each_with_index do |payment_request, index|
           params.merge! payment_request.to_params(index)


### PR DESCRIPTION
This is a fix for the 10006 Version is not supported" error: https://developer.paypal.com/docs/classic/api/errorcodes/#id09C3E1009E9

Paypal now requires a version for requests. For more info see http://stackoverflow.com/questions/29196337/