### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,17 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.0.0
-  - 2.1.2
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
+
+env:
+  - RAILS_VERSION="~> 2.3"
+  - RAILS_VERSION="~> 3.0"
+  - RAILS_VERSION="~> 4.0"
+  - RAILS_VERSION="~> 5.0"
+
+matrix:
+  exclude:
+    - rvm: 2.1.10
+      env: RAILS_VERSION="~> 5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,13 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 platform :jruby do
   gem 'jruby-openssl', '>= 0.7'
+end
+
+if ENV['RAILS_VERSION']
+  gem 'activesupport', ENV['RAILS_VERSION']
+
+  gem 'iconv' if ENV['RAILS_VERSION'] == '~> 2.3'
 end
 
 gemspec


### PR DESCRIPTION
Rails 5.0 requires Ruby 2.2.2 or the above. Ruby 2.0 is dropped from targets because it isn't supported already.
(The lowest version of Rails is based on gemspec for now now)