### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,6 +5,7 @@ Both Instance Payment and Recurring Payment are supported.
 Express Checkout for Digital Goods is also supported.
 
 {<img src="https://secure.travis-ci.org/nov/paypal-express.png" />}[http://travis-ci.org/nov/paypal-express]
+{<img src="https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg" />}[hhttps://rapidapi.com/package/PayPal/functions?utm_source=PaypalGithub&utm_medium=button&utm_content=Vender_GitHub]
 
 == Installation
 


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out Paypal API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!